### PR TITLE
feat(core): nested repeater expansion for structure syntax

### DIFF
--- a/packages/core/src/get-structure.ts
+++ b/packages/core/src/get-structure.ts
@@ -15,6 +15,7 @@ import {
 } from "./utils/frontmatter-parser.js"; // Import frontmatter utils
 // Removed incorrect Replacements import
 import { handleOperationError } from "./utils/error-utils.js";
+import { expandRepeaters } from "./utils/repeater-expansion.js";
 import { applyReplacements } from "./utils/replacements.js";
 import { validateOperation } from "./utils/validation.js";
 import { createMessage } from "./warnings.js";
@@ -388,6 +389,7 @@ export async function getStructure(
 ): Promise<GetStructureResult> {
   const { rootDir } = options;
   const { frontmatter, content } = parseFrontmatter(input);
+  const expandedContent = expandRepeaters(content);
 
   // Merge frontmatter and options replacements here
   const mergedReplacements = mergeReplacements(frontmatter, options);
@@ -399,7 +401,9 @@ export async function getStructure(
 
   const operations: (StructureOperation & { orderIndex: number })[] = [];
   let orderIndex = 0;
-  const lines = content.split("\n").filter((line) => line.trim().length > 0);
+  const lines = expandedContent
+    .split("\n")
+    .filter((line) => line.trim().length > 0);
   const stack: string[] = [rootDir];
 
   for (const line of lines) {

--- a/packages/core/src/utils/repeater-expansion.ts
+++ b/packages/core/src/utils/repeater-expansion.ts
@@ -1,0 +1,86 @@
+const REPEATER_PATTERN = /\$\*(\d+)/g;
+const MAX_REPEAT_COUNT = 1000;
+
+/**
+ * Expands Emmet-like repeaters in structure lines.
+ * Example: `file_$*3.txt` becomes file_1..file_3 on separate lines.
+ */
+export function expandRepeaters(content: string): string {
+  if (!content.includes("$*")) {
+    return content;
+  }
+
+  const lines = content.split("\n");
+  return expandLines(lines).join("\n");
+}
+
+function expandLines(lines: string[]): string[] {
+  const expandedLines: string[] = [];
+  let index = 0;
+
+  while (index < lines.length) {
+    const line = lines[index];
+    const matches = [...line.matchAll(REPEATER_PATTERN)];
+
+    if (matches.length === 0) {
+      expandedLines.push(line);
+      index += 1;
+      continue;
+    }
+
+    const counts = new Set(
+      matches.map((match) => Number.parseInt(match[1], 10))
+    );
+
+    // Keep line unchanged when repeater counts are mixed (e.g. $*2 and $*3).
+    if (counts.size !== 1) {
+      expandedLines.push(line);
+      index += 1;
+      continue;
+    }
+
+    const repeatCount = counts.values().next().value as number;
+    if (!Number.isFinite(repeatCount) || repeatCount < 1) {
+      expandedLines.push(line);
+      index += 1;
+      continue;
+    }
+
+    const currentLevel = getIndentationLevel(line);
+    let blockEnd = index + 1;
+
+    // Capture the full indented subtree under this line.
+    while (blockEnd < lines.length) {
+      const candidate = lines[blockEnd];
+      if (candidate.trim().length === 0) {
+        blockEnd += 1;
+        continue;
+      }
+      if (getIndentationLevel(candidate) <= currentLevel) {
+        break;
+      }
+      blockEnd += 1;
+    }
+
+    const childLines = lines.slice(index + 1, blockEnd);
+    const boundedRepeatCount = Math.min(repeatCount, MAX_REPEAT_COUNT);
+
+    for (let i = 1; i <= boundedRepeatCount; i += 1) {
+      expandedLines.push(line.replace(REPEATER_PATTERN, String(i)));
+      if (childLines.length > 0) {
+        expandedLines.push(...expandLines(childLines));
+      }
+    }
+
+    index = blockEnd;
+  }
+
+  return expandedLines;
+}
+
+function getIndentationLevel(line: string): number {
+  const indentation = line.match(/^\s+/)?.[0] || "";
+  return indentation.includes("\t")
+    ? indentation.split("\t").length - 1
+    : indentation.length / 4;
+}

--- a/packages/core/tests/create-structure.test.ts
+++ b/packages/core/tests/create-structure.test.ts
@@ -150,6 +150,51 @@ src
     ).resolves.toBe(true);
   });
 
+  test("expands emmet-like repeaters during creation", async () => {
+    const input = `
+src
+    filename_$*3.psd
+`;
+
+    await createStructure(input, {
+      rootDir: testDir,
+      fs,
+    });
+
+    expect(fs.exists(path.join(testDir, "src", "filename_1.psd"))).resolves.toBe(
+      true
+    );
+    expect(fs.exists(path.join(testDir, "src", "filename_2.psd"))).resolves.toBe(
+      true
+    );
+    expect(fs.exists(path.join(testDir, "src", "filename_3.psd"))).resolves.toBe(
+      true
+    );
+  });
+
+  test("creates nested content inside each repeated folder", async () => {
+    const input = `
+root
+    0_$*3
+        test
+`;
+
+    await createStructure(input, {
+      rootDir: testDir,
+      fs,
+    });
+
+    expect(fs.exists(path.join(testDir, "root", "0_1", "test"))).resolves.toBe(
+      true
+    );
+    expect(fs.exists(path.join(testDir, "root", "0_2", "test"))).resolves.toBe(
+      true
+    );
+    expect(fs.exists(path.join(testDir, "root", "0_3", "test"))).resolves.toBe(
+      true
+    );
+  });
+
   test("handles missing source files gracefully", async () => {
     const input = `
 src


### PR DESCRIPTION
## Summary
- add Emmet-like repeater expansion in core parsing ()
- expand repeated lines as full blocks, so nested children are repeated per parent
- apply expansion before operation parsing in 
- add parser + creation tests for nested repeated folders and nested repeaters

## Example
Input:

Output structure now includes:
- 
- 
- 

## Validation
- 
> @filearchitect/monorepo@0.0.21 test /Users/sebastienlavoie/Code/js/filearchitect
> vitest run --config ./vitest.config.ts --reporter verbose


 RUN  v1.6.1 /Users/sebastienlavoie/Code/js/filearchitect

 ✓ packages/core/tests/get-structure.test.ts > getStructure > creates basic file structure
 ✓ packages/core/tests/get-structure.test.ts > getStructure > handles file copying
 ✓ packages/core/tests/get-structure.test.ts > getStructure > handles file moving
 ✓ packages/core/tests/get-structure.test.ts > getStructure > applies file name replacements
 ✓ packages/core/tests/get-structure.test.ts > getStructure > expands emmet-like repeaters for file creation
 ✓ packages/core/tests/get-structure.test.ts > getStructure > repeats nested content for each repeated folder
 ✓ packages/core/tests/get-structure.test.ts > getStructure > expands nested repeaters inside repeated folders
 ✓ packages/core/tests/get-structure.test.ts > getStructure > expands repeaters for copy operation targets
 ✓ packages/core/tests/get-structure.test.ts > getStructure > handles missing source files
 ✓ packages/core/tests/get-structure.test.ts > getStructure > recursively copies directories
 ✓ packages/core/tests/get-structure.test.ts > getStructure > parses frontmatter with replacements
 ✓ packages/core/tests/get-structure.test.ts > getStructure > applies replacements to copied files and directories
 ✓ packages/core/tests/get-structure.test.ts > getStructure > applies replacements to moved files and directories
 ✓ packages/core/tests/get-structure.test.ts > getStructure > applies all replacements from frontmatter and options
 ✓ packages/core/tests/get-structure.test.ts > getStructure > combines all replacements with type-specific
 ✓ packages/core/tests/get-structure.test.ts > getStructure > handles escaped dots in directory names
 ✓ packages/core/tests/get-structure.test.ts > getStructure > handles escaped dots in file names
 ✓ packages/core/tests/get-structure.test.ts > getStructure > handles mixed escaped and unescaped dots
 ✓ packages/core/tests/get-structure.test.ts > getStructure > handles escaped dots in copy operations
 ✓ packages/core/tests/get-structure.test.ts > getStructure > handles escaped dots in move operations
 ✓ packages/core/tests/get-structure.test.ts > getStructure > handles escaped dots with trailing slash directory markers
 ✓ packages/core/tests/create-structure.test.ts > createStructure > creates a basic file structure
 ✓ packages/core/tests/create-structure.test.ts > createStructure > copies files and preserves content
 ✓ packages/core/tests/create-structure.test.ts > createStructure > moves files and removes source
 ✓ packages/core/tests/create-structure.test.ts > createStructure > copies directories recursively
 ✓ packages/core/tests/create-structure.test.ts > createStructure > applies file name replacements during creation
 ✓ packages/core/tests/create-structure.test.ts > createStructure > expands emmet-like repeaters during creation
 ✓ packages/core/tests/create-structure.test.ts > createStructure > creates nested content inside each repeated folder
 ✓ packages/core/tests/create-structure.test.ts > createStructure > handles missing source files gracefully
 ✓ packages/core/tests/create-structure.test.ts > createStructure > creates structure with frontmatter replacements
 ✓ packages/core/tests/create-structure.test.ts > createStructure > applies replacements to copied files and directories
 ✓ packages/core/tests/create-structure.test.ts > createStructure > applies replacements to moved files and directories
 ✓ packages/core/tests/create-structure.test.ts > createStructure > applies all replacements to both files and folders
 ✓ packages/core/tests/create-structure.test.ts > createStructure > applies replacements in correct priority order
 ✓ packages/core/tests/create-structure.test.ts > createStructure > creates directories with escaped dots in names
 ✓ packages/ui/src/components/StructureInput.test.tsx > StructureInput > calls onStructureChange with the latest value when text is typed
 ✓ packages/ui/src/components/StructureInput.test.tsx > StructureInput > indents current line on Tab press and updates selection
 ✓ packages/ui/src/components/StructureInput.test.tsx > StructureInput > Shift+Tab unindents current line and updates selection
 ✓ packages/ui/src/components/StructureInput.test.tsx > StructureInput > adds new line with indentation on Enter press and updates selection
 ✓ packages/ui/src/components/StructureInput.test.tsx > StructureInput > does not add new line if on an empty line and Enter is pressed
 ✓ packages/ui/src/components/StructureInput.test.tsx > StructureInput > prevents adding new lines via Enter if maxLines is reached
 ✓ packages/ui/src/components/StructureInput.test.tsx > StructureInput > truncates pasted text that exceeds maxLines
 ✓ packages/ui/src/components/StructureInput.test.tsx > StructureInput > textarea is disabled when disabled prop is true

 Test Files  3 passed (3)
      Tests  43 passed (43)
   Start at  23:47:23
   Duration  955ms (transform 177ms, setup 141ms, collect 505ms, tests 285ms, environment 797ms, prepare 173ms) (monorepo)